### PR TITLE
refactor(homepage): Use only TeamGenerator in Homepage. Closes #20

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,9 @@
 import { TeamGenerator } from "./components/TeamGenerator";
-import { GeneratedTeamsList } from "./components/GeneratedTeamsList";
 
 export default function Home() {
   return (
-    <main className="container mx-auto py-12 px-2">
-      <h1 className="text-3xl font-bold text-center">NoCliques</h1>
-      <p className="text-center mt-4">
-        NoCliques is a team generator app designed to create fair and balanced
-        teams avoiding the famous "cliques".
-      </p>
-      <div className="flex flex-col gap-6 mt-8 items-center">
-        <TeamGenerator />
-        <GeneratedTeamsList />
-      </div>
+    <main>
+      <TeamGenerator />
     </main>
   );
 }


### PR DESCRIPTION
# 🛠️ Modify Home Page to Use Only TeamGenerator  

## 📌 Description  
This PR updates the **Home Page** to include only the `TeamGenerator` component, simplifying the layout.  

## ✅ Changes  
- Removed unused components from the Home Page.  
- Placed `TeamGenerator` as the main element.  

## 🔍 Testing  
- [ ] Ensure the Home Page loads without errors.  
- [ ] Confirm `TeamGenerator` appears as expected.  

## 🔗 Related Issue  
Closes #20 
