### PR TITLE
style(TeamGenerator): Improve TeamGenerator layout. Closes #32

### DIFF
--- a/src/app/components/TeamGenerator.tsx
+++ b/src/app/components/TeamGenerator.tsx
@@ -24,7 +24,10 @@ export function TeamGenerator() {
           teams avoiding the famous "cliques".
         </p>
       </header>
-      <section aria-labelledby="input-section" className="p-6 pt-0 space-y-6">
+      <section
+        aria-labelledby="input-section"
+        className="lg:flex lg:flex-row lg:gap-6 p-6 pt-0 space-y-6 lg:space-y-0"
+      >
         <PlayersList />
         <TeamsList />
       </section>
@@ -32,10 +35,10 @@ export function TeamGenerator() {
         <GeneratedTeamsList />
       </section>
       <footer className="flex flex-row justify-between items-center p-6 pt-0">
-        <Button aria-label="Reset" type="button" variant="outline">
+        <Button aria-label="Reset" type="button" variant="secondary">
           Reset
         </Button>
-        <Button aria-label="Generate Teams" type="submit">
+        <Button aria-label="Generate Teams" type="button">
           Generate Teams
         </Button>
       </footer>


### PR DESCRIPTION
# style(TeamGenerator): Display PlayersList and TeamsList side by side on larger screens  

## Description  
This PR updates the layout of the `TeamGenerator` component to position `PlayersList` and `TeamsList` side by side on larger screens while maintaining a responsive and accessible design.  

## Changes  
- Used Tailwind CSS `flex` or `grid` utilities to align `PlayersList` and `TeamsList` side by side on larger screens.  
- Ensured proper spacing and alignment between both components.  
- Maintained a stacked layout for smaller screens to preserve usability.  
- Verified responsiveness across multiple screen sizes.  
- Fix buttons types

## How to Test  
1. Navigate to the `TeamGenerator` component.  
2. Resize the screen to a larger width and verify that `PlayersList` and `TeamsList` appear side by side.  
3. Check smaller screen sizes to ensure the components stack correctly.  
4. Inspect spacing and alignment for visual consistency.  

## Notes  
- The layout remains clean and user-friendly across different devices.  
- No breaking changes were introduced.  

## Related Issues  
Closes #32 
