### PR TITLE
fix(teamGeneratorUtils): remove duplicate import of POSITION_ORDER

### DIFF
--- a/src/app/utils/teamGeneratorUtils.ts
+++ b/src/app/utils/teamGeneratorUtils.ts
@@ -8,9 +8,6 @@ import { Player, Team, GeneratedTeams } from "@/app/types/entityTypes";
 // Constants
 import { POSITION_ORDER } from "@/app/constants/entityDefaults";
 
-// Constants
-import { POSITION_ORDER } from "@/app/constants/entityDefaults";
-
 /**
  * Counts the total number of players in a given team.
  */


### PR DESCRIPTION
## ✅ Fix: Remove Duplicate Import of `POSITION_ORDER`

### 📄 Summary
This PR removes a **redundant import** of the `POSITION_ORDER` constant from `teamGeneratorUtils.ts`. Only a single import is now retained for better clarity and maintainability.

### 🔧 Changes
- ✅ Removed unnecessary import of `POSITION_ORDER`
- ✅ Verified references within the file point to the correct constant

### 📁 Affected File
- `src/utils/teamGeneratorUtils.ts`

### 📚 Context
This is part of ongoing cleanup efforts to keep utility files lean and DRY. Duplicate imports can confuse readers and introduce bugs during refactoring or testing.

### ✅ Checklist
- [x] Code compiles correctly
- [x] No functionality was affected
- [x] Only one instance of `POSITION_ORDER` exists in the file

---

Closes #92 
